### PR TITLE
chore: migrate npm renovate preset to github [no issue]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["config:js-app", "@ornikar"],
+  "extends": ["config:js-app", "github>ornikar/renovate-presets:frontend-legacy"],
   "lockFileMaintenance": { "enabled": true }
 }


### PR DESCRIPTION
### Context

According to [the Renovate documentation](https://docs.renovatebot.com/config-presets/#npm-hosted-presets):
> Using npm-hosted presets is deprecated, we recommend you do not follow these instructions and instead use a local preset.

### Solution

Add the NPM-based Renovate config as a GitHub-hosted preset, to avoid deprecation.
